### PR TITLE
Fix broken pvPortReallocMicroROS() implementation

### DIFF
--- a/extra_sources/custom_memory_manager.c
+++ b/extra_sources/custom_memory_manager.c
@@ -4,6 +4,7 @@
  */
  
 #include <stdlib.h>
+#include <string.h>
 
 /* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
 all the API functions to use the MPU wrappers.  That should only be done when
@@ -293,22 +294,17 @@ void *pvPortReallocMicroROS( void *pv, size_t xWantedSize )
 	vTaskSuspendAll();
 
 	void * newmem = pvPortMallocMicroROS(xWantedSize);
+	if (newmem != NULL)
+	{
+		size_t count = getBlockSize(pv) - xHeapStructSize;
+		if (xWantedSize < count)
+		{
+			count = xWantedSize;
+		}
+		memcpy(newmem, pv, count);
 
-	uint8_t *puc = ( uint8_t * ) pv;
-	BlockLink_t *pxLink;
-
-	puc -= xHeapStructSize;
-	pxLink = ( void * ) puc;
-
-
-	char *in_src = (char*)pv;
-  	char *in_dest = (char*)newmem;
-	size_t count = pxLink->xBlockSize & ~xBlockAllocatedBit;
-
-  	while(count--)
-    	*in_dest++ = *in_src++;
-
-	vPortFreeMicroROS(pv);
+		vPortFreeMicroROS(pv);
+	}
 
 	( void ) xTaskResumeAll();
 


### PR DESCRIPTION
The original `pvPortReallocMicroROS()` implementation copies more bytes than expected, which causes memory error when using functions like `rosidl_runtime_c__String__assignn()`.