### PR TITLE
microros_component/extra_packages support

### DIFF
--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,8 +26,13 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        cp -R /project/microros_component/extra_packages/* .
-        vcs import --input extra_packages.repos
+    	USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
+    		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
+		fi
+        if [ -f extra_packages.repos ]; then
+        	vcs import --input extra_packages.repos
+        fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,6 +26,8 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
+        cp -R /project/microros_component/extra_packages/* .
+        vcs import --input extra_packages.repos
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,12 +26,12 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-    	USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi
-        if [ -f extra_packages.repos ]; then
-        	vcs import --input extra_packages.repos
+        if [ -f $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos ]; then
+        	vcs import --input $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos
         fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,12 +45,12 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+        USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi
-        if [ -f extra_packages.repos ]; then
-        	vcs import --input extra_packages.repos
+        if [ -f $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos ]; then
+        	vcs import --input $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos
         fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,8 +45,13 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        cp -R /project/microros_component/extra_packages/* .
-        vcs import --input extra_packages.repos
+        USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
+    		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
+		fi
+        if [ -f extra_packages.repos ]; then
+        	vcs import --input extra_packages.repos
+        fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,6 +45,8 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
+        cp -R /project/microros_component/extra_packages/* .
+        vcs import --input extra_packages.repos
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null


### PR DESCRIPTION
For convenience and maintaining modularity, it is better to keep custom packages outside the [micro_ros_stm32cubemx_utils](https://github.com/micro-ROS/micro_ros_stm32cubemx_utils). This has been specified in the [Readme](https://github.com/micro-ROS/micro_ros_stm32cubemx_utils/tree/foxy#adding-custom-packages), but as I looked into the code wasn't able to find anywhere implemented. 