### PR TITLE
Fix USER_CUSTOM_PACKAGES_DIR

### DIFF
--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,8 +26,13 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        cp -R /project/microros_component/extra_packages/* .
-        vcs import --input extra_packages.repos
+    	USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
+    		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
+		fi
+        if [ -f extra_packages.repos ]; then
+        	vcs import --input extra_packages.repos
+        fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,6 +26,8 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
+        cp -R /project/microros_component/extra_packages/* .
+        vcs import --input extra_packages.repos
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,7 +26,7 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-    	USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
+    	USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi

--- a/microros_static_library/library_generation/library_generation.sh
+++ b/microros_static_library/library_generation/library_generation.sh
@@ -26,12 +26,12 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-    	USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi
-        if [ -f extra_packages.repos ]; then
-        	vcs import --input extra_packages.repos
+        if [ -f $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos ]; then
+        	vcs import --input $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos
         fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,12 +45,12 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+        USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi
-        if [ -f extra_packages.repos ]; then
-        	vcs import --input extra_packages.repos
+        if [ -f $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos ]; then
+        	vcs import --input $USER_CUSTOM_PACKAGES_DIR/extra_packages.repos
         fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,8 +45,13 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        cp -R /project/microros_component/extra_packages/* .
-        vcs import --input extra_packages.repos
+        USER_CUSTOM_PACKAGES_DIR=/project/microros_component/extra_packages 
+    	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
+    		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
+		fi
+        if [ -f extra_packages.repos ]; then
+        	vcs import --input extra_packages.repos
+        fi
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,6 +45,8 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
+        cp -R /project/microros_component/extra_packages/* .
+        vcs import --input extra_packages.repos
         cp -R $BASE_PATH/library_generation/extra_packages/* .
         vcs import --input extra_packages.repos
     popd > /dev/null

--- a/microros_static_library_ide/library_generation/library_generation.sh
+++ b/microros_static_library_ide/library_generation/library_generation.sh
@@ -45,7 +45,7 @@ pushd firmware/mcu_ws > /dev/null
     # Import user defined packages
     mkdir extra_packages
     pushd extra_packages > /dev/null
-        USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../microros_component/extra_packages 
+        USER_CUSTOM_PACKAGES_DIR=$BASE_PATH/../../microros_component/extra_packages 
     	if [ -d "$USER_CUSTOM_PACKAGES_DIR" ]; then
     		cp -R $USER_CUSTOM_PACKAGES_DIR/* .
 		fi


### PR DESCRIPTION
On the last pull request I hadnt realise that $MICROROS_LIBRARY_FOLDER is of depth 2.  So need to go back twice to go from $BASE_PATH to $USER_CUSTOM_PACKAGES_DIR. after fixing this the build is able to pick packages from microros_component/extra_packages